### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Keep in mind that this is only updated when releases are made and the file
+is generated automatically from commit messages (and may or may not be lightly
+edited).
+
+For a possibly more edited message focused on the binary please see the github
+releases.
+
+## [0.1.1] - 2025-02-25
+
+### 🚀 Features
+
+- Allow skipping fuzzy matches if exact matches are found
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "filkoll"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap_mangen = "0.2.26"
 color-eyre = "0.6.3"
 compact_str = { version = "0.9.0", features = ["smallvec"] }
 eyre = "0.6.12"
-filkoll = { version = "0.1.0", path = "crates/filkoll" }
+filkoll = { version = "0.1.1", path = "crates/filkoll" }
 flate2 = { version = "1.1.0", default-features = false, features = ["zlib-rs"] }
 hashbrown = "0.15.2"
 indoc = "2.0.5"

--- a/crates/filkoll/Cargo.toml
+++ b/crates/filkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "filkoll"
 readme = "../../README.md"
 repository = "https://github.com/VorpalBlade/filkoll"
 rust-version = "1.85.0"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 anstream.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `filkoll`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2025-02-25

### 🚀 Features

- Allow skipping fuzzy matches if exact matches are found
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).