### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.2] - 2025-03-25
+
+### 🐛 Bug fixes
+
+- Create cache directory if missing
+
+### 🩺 Diagnostics & output formatting
+
+- Reduce amount of debug output from update command
+
+### 🧪 Testing
+
+- Add more unit tests
+
+### ⚙️ Other stuff
+
+- *(docs)* Typo fixes
+- Add missing invariant
+
 ## [0.2.1] - 2025-02-28
 
 ### ⚡ Performance improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "filkoll"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/filkoll/Cargo.toml
+++ b/crates/filkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "filkoll"
 readme = "../../README.md"
 repository = "https://github.com/VorpalBlade/filkoll"
 rust-version = "1.85.0"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 anstream.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `filkoll`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2] - 2025-03-25

### 🐛 Bug fixes

- Create cache directory if missing

### 🩺 Diagnostics & output formatting

- Reduce amount of debug output from update command

### 🧪 Testing

- Add more unit tests

### ⚙️ Other stuff

- *(docs)* Typo fixes
- Add missing invariant
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).