### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.5] - 2025-05-17
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.2.4] - 2025-04-18
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "filkoll"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/filkoll/Cargo.toml
+++ b/crates/filkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "filkoll"
 readme = "../../README.md"
 repository = "https://github.com/VorpalBlade/filkoll"
 rust-version = "1.85.0"
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 anstream.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `filkoll`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5] - 2025-05-17

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).