### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.7] - 2025-09-14
+
+### 🐛 Bug fixes
+
+- Fix incorrect suggestion
+
+### 🩺 Diagnostics & output formatting
+
+- Improve message for no exact match
+
+### ⚙️ Other stuff
+
+- Update to Rust 1.88.0
+
 ## [0.2.6] - 2025-06-02
 
 ### 🩺 Diagnostics & output formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "filkoll"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/filkoll/Cargo.toml
+++ b/crates/filkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "filkoll"
 readme = "../../README.md"
 repository = "https://github.com/VorpalBlade/filkoll"
 rust-version = "1.88.0"
-version = "0.2.6"
+version = "0.2.7"
 
 [dependencies]
 anstream.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `filkoll`: 0.2.6 -> 0.2.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.7] - 2025-09-14

### 🐛 Bug fixes

- Fix incorrect suggestion

### 🩺 Diagnostics & output formatting

- Improve message for no exact match

### ⚙️ Other stuff

- Update to Rust 1.88.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).